### PR TITLE
Add 'arrangeall' events for multiple flows

### DIFF
--- a/src/auto-arrange.js
+++ b/src/auto-arrange.js
@@ -62,10 +62,10 @@ export class AutoArrange {
         let lastBoardSize = 0;
 
         this.editor.nodes.forEach((node) => {
-            if (!inBoard.has(node.name)) {
+            if (!inBoard.has(node)) {
                 const board = this.getNodesBoard(node);
                 board.getValues().forEach((boardNode) => {
-                    inBoard.add(boardNode.name);
+                    inBoard.add(boardNode);
                 });
                 const currentBoardSize = this.getBoardSize(board);
                 if (this.vertical) {

--- a/src/board.js
+++ b/src/board.js
@@ -16,4 +16,14 @@ export class Board {
 
         return normalized;
     }
+
+    getValues() {
+        const values = [];
+        this._cols.forEach((col) => {
+            col.forEach((value) => {
+                values.push(value);
+            });
+        });
+        return values;
+    }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,12 @@ import { AutoArrange } from './auto-arrange';
 
 function install(editor, { margin = { x: 50, y: 50 }, depth = null, vertical = false }) {
     editor.bind('arrange');
+    editor.bind('arrangeall');
 
     const ar = new AutoArrange(editor, margin, depth, vertical);
     
     editor.on('arrange', ({ node }) => ar.arrange(node));
+    editor.on('arrangeall', () => ar.arrangeAll());
 
     editor.arrange = node => {
         console.log(`Deprecated: use editor.trigger('arrange', { node }) instead`);


### PR DESCRIPTION
I created a new event `arrangeall` that arranges all the nodes to solve the multiple flows issue mentioned in #16. 

Basically, it looks for all the flows and compute their `NodeBoard`, then arrange them one by one with an offset so that they don't overlap.