### PR TITLE
Make arrange options overridable when invoking arrange trigger

### DIFF
--- a/src/auto-arrange.js
+++ b/src/auto-arrange.js
@@ -2,11 +2,12 @@ import { Board } from './board';
 import { Cache } from './cache';
 
 export class AutoArrange {
-    constructor(editor, margin, depth, vertical) {
+    constructor(editor, margin, depth, vertical, offset) {
         this.editor = editor;
         this.margin = margin;
         this.depth = depth;
         this.vertical = vertical;
+        this.offset = offset;
     }
 
     getNodes(node, type = 'output') {
@@ -51,18 +52,19 @@ export class AutoArrange {
         this.editor.view.updateConnections({ node });
     }
     
-    arrange(node = this.editor.nodes[0], { margin = this.margin, vertical = this.vertical, depth = this.depth }) {
+    arrange(node = this.editor.nodes[0], { margin = this.margin, vertical = this.vertical, depth = this.depth, offset = this.offset }) {
         const board = this.getNodesBoard(node, depth).toArray();
         const currentMargin = vertical ? { x: margin.y, y: margin.x } : margin;
+        const currentOffset = vertical ? { x: offset.y, y: offset.x } : offset;
 
-        let x = 0;
+        let x = currentOffset.x;
 
         for (let column of board) {
             const sizes = column.map(node => this.getNodeSize(node, vertical));
             const columnWidth  = Math.max(...sizes.map(size => size.width));
             const fullHeight = sizes.reduce((sum, node) => sum + node.height + currentMargin.y, 0);
 
-            let y = 0;
+            let y = currentOffset.y;
 
             for (let node of column) {
                 const position = { x, y: y - fullHeight / 2, vertical };

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import { AutoArrange } from './auto-arrange';
 function install(editor, { margin = { x: 50, y: 50 }, depth = null, vertical = false, offset = { x: 0, y: 0 } }) {
     editor.bind('arrange');
 
-    const ar = new AutoArrange(editor, margin, depth, vertical);
+    const ar = new AutoArrange(editor, margin, depth, vertical, offset);
     
     editor.on('arrange', ({ node, ...options }) => ar.arrange(node, options));
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { AutoArrange } from './auto-arrange';
 
-function install(editor, { margin = { x: 50, y: 50 }, depth = null, vertical = false }) {
+function install(editor, { margin = { x: 50, y: 50 }, depth = null, vertical = false, offset = { x: 0, y: 0 } }) {
     editor.bind('arrange');
 
     const ar = new AutoArrange(editor, margin, depth, vertical);

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ function install(editor, { margin = { x: 50, y: 50 }, depth = null, vertical = f
 
     const ar = new AutoArrange(editor, margin, depth, vertical);
     
-    editor.on('arrange', ({ node }) => ar.arrange(node));
+    editor.on('arrange', ({ node, ...options }) => ar.arrange(node, options));
 
     editor.arrange = node => {
         console.log(`Deprecated: use editor.trigger('arrange', { node }) instead`);


### PR DESCRIPTION
This PR code will enable the developer to override attributes from the initial plugin registration when calling
```
editor.trigger('arrange', { node, options })
```
Where the options parameter is an object of the following overridable attributes
* margin
* vertical
* depth
* offset (new parameter that offsets the entire arrangement in x and y directions)